### PR TITLE
Upgrade OpenSearch to 2.11.1

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "polarVisPlugin",
   "version": "0.14.2",
-  "opensearchDashboardsVersion": "2.10.0",
+  "opensearchDashboardsVersion": "2.11.1",
   "server": false,
   "ui": true,
   "requiredPlugins": [

--- a/releases/unreleased/upgrade-to-opensearch-dashboards-2111.yml
+++ b/releases/unreleased/upgrade-to-opensearch-dashboards-2111.yml
@@ -1,0 +1,9 @@
+---
+title: Upgrade to OpenSearch Dashboards 2.11.1
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  OpenSearch Dashboard has been updated to 2.11.1
+  version to fix the problems found navigating
+  between dashboards.


### PR DESCRIPTION
This PR upgrades the OpenSearch Dashboards version to 2.11.1.