### PR TITLE
Upgrade to OpenSearch Dashboards 2.16

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "polarVisPlugin",
   "version": "0.22.0-rc.1",
-  "opensearchDashboardsVersion": "2.11.1",
+  "opensearchDashboardsVersion": "2.16.0",
   "server": false,
   "ui": true,
   "requiredPlugins": [

--- a/releases/unreleased/upgrade-opensearch-dashboards-version-to-216.yml
+++ b/releases/unreleased/upgrade-opensearch-dashboards-version-to-216.yml
@@ -1,0 +1,8 @@
+---
+title: Upgrade to OpenSearch Dashboards 2.16
+category: dependency
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  OpenSearch Dashboards 2.16 fixes an issue with the colors of the 
+  visualizations when there are more than 10 items.


### PR DESCRIPTION
Bumps OpenSearch Dashboards to version 2.16 and updates how the Node version is resolved in the GitHub workflow.