### PR TITLE
Fix Node and Yarn version files in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,20 +32,17 @@ jobs:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ steps.osd_version.outputs.version }}
           path: osd
-      - name: Get node and yarn versions
-        id: versions
-        run: |
-          echo "::set-output name=node_version::$(node -p "(require('./osd/package.json').engines.node).match(/[.0-9]+/)[0]")"
-          echo "::set-output name=yarn_version::$(node -p "require('./osd/package.json').engines.yarn")"
       - name: Setup node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # 3.6.0
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # 4.0.1
         with:
-          node-version: ${{ steps.versions.outputs.node_version }}
+          node-version-file: './osd/.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup yarn
         run: |
           npm uninstall -g yarn
-          echo "Installing yarn ${{ steps.versions.outputs.yarn_version }}"
-          npm i -g yarn@${{ steps.versions.outputs.yarn_version }}
+          YARN_VERSION=$(node -p "require('./osd/package.json').engines.yarn")
+          echo "Installing yarn @$YARN_VERSION"
+          npm i -g yarn@$YARN_VERSION
       - name: Move plugin to OpenSearch Dashboards folder
         run: |
           mkdir -p osd/plugins


### PR DESCRIPTION
Changes the GitHub release workflow to get the Node and Yarn version files from the right path.