### PR TITLE
Update OpenSearch Dashboards version to 3.2.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "polarVisPlugin",
   "version": "0.33.0-rc.3",
-  "opensearchDashboardsVersion": "2.16.0",
+  "opensearchDashboardsVersion": "3.2.0",
   "server": false,
   "ui": true,
   "requiredPlugins": [

--- a/releases/unreleased/plugin-compability-for-opensearch-dashboards-320.yml
+++ b/releases/unreleased/plugin-compability-for-opensearch-dashboards-320.yml
@@ -1,0 +1,7 @@
+---
+title: Upgrade to OpenSearch Dashboards 3.2.0
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Upgrade plugin compatibility with OpenSearch Dashboards 3.2.0.


### PR DESCRIPTION
This change updates the version of OpenSearch Dashboards to 3.2.0. This is necessary to ensure compatibility with new features and improvements in the latest release.