### PR TITLE
Update OpenSearch Dashboards version to 3.7.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "polarVisPlugin",
   "version": "0.39.0",
-  "opensearchDashboardsVersion": "3.6.0",
+  "opensearchDashboardsVersion": "3.7.0",
   "server": false,
   "ui": true,
   "requiredPlugins": [

--- a/releases/unreleased/upgrade-to-opensearch-dashboards-370.yml
+++ b/releases/unreleased/upgrade-to-opensearch-dashboards-370.yml
@@ -1,0 +1,7 @@
+---
+title: Upgrade to OpenSearch Dashboards 3.7.0
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Upgrade plugin compatibility with OpenSearch Dashboards 3.7.0


### PR DESCRIPTION
This change updates the version of OpenSearch Dashboards to 3.7.0. This is necessary to ensure compatibility with new features and improvements in the latest release.